### PR TITLE
Support for custom request headers in query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ docker run -p 3000:3000 -d mercury-parser-api
 
 ## Usage
 
-GET /parser?url=[required:url]&contentType=[optional:contentType]
+GET /parser?url=[required:url]&contentType=[optional:contentType]&headers=[optional:url-encoded-headers]
 
 ```bash
 curl localhost:3000/parser?url=https://www.bbc.co.uk/news/science-environment-35876621

--- a/routes.js
+++ b/routes.js
@@ -13,8 +13,13 @@ router.route('/parser').get(async (req, res) => {
     if (req.query.url) {
         try {
             const contentType = req.query.contentType || 'html';
+            let headers = new Object();
+            if (typeof(req.query.headers) !== 'undefined') {
+                headers = JSON.parse(req.query.headers);
+            }
             result = await Mercury.parse(req.query.url, {
                 contentType,
+                headers
             });
         } catch (error) {
             result = { error: true, messages: error.message };

--- a/routes.js
+++ b/routes.js
@@ -14,7 +14,7 @@ router.route('/parser').get(async (req, res) => {
         try {
             const contentType = req.query.contentType || 'html';
             let headers = new Object();
-            if (typeof(req.query.headers) !== 'undefined') {
+            if (typeof req.query.headers !== 'undefined') {
                 headers = JSON.parse(req.query.headers);
             }
             result = await Mercury.parse(req.query.url, {


### PR DESCRIPTION
In some websites, additional cookies are needed to handle anti-spider issue. We can set cookies through headers in such case.