### PR TITLE
adds /parse-html endpoint

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -31,4 +31,19 @@ router.route('/parser').get(async (req, res) => {
     return res.json(result);
 });
 
+router.route('/parse-html').post(async (req, res) => {
+    let result = { message: 'No URL was provided' };
+
+    if (req.body.url && req.body.html) {
+        try {
+            result = await Mercury.parse(req.body.url, {
+              html: req.body.html
+            });
+        } catch (error) {
+            result = { error: true, messages: error.message };
+        }
+    }
+    return res.json(result);
+});
+
 module.exports = router;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

In order to get this change merged in a timely manner, please provide a short
description, review requirements, and a link to the issue this addresses (if applicable).

Contributing Guide: https://github.com/postlight/mercury-parser-api/blob/master/CONTRIBUTING.md
-->

Closes #416.

Adds `/parse-html` endpoint that receives `url` and `html` in the body of a POST request. 

Usage example snippet (in python):

```
url = f"{self.api_endpoint}/parse-html"
data = {'url': article_url, 'html': html}
response = requests.post(url=url, data=data)
```
